### PR TITLE
Add rates for 2022

### DIFF
--- a/src/rates/rates.ts
+++ b/src/rates/rates.ts
@@ -12,7 +12,7 @@ interface Rates {
 
 export const rates: Rates = {
   fromYear: 2017,
-  toYear: 2021,
+  toYear: 2022,
   countries: { 
     "AD": [ 
       { 


### PR DESCRIPTION
The rates in 2022 will be unchanged from 2021, as stated in the [official announcement](https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Steuerarten/Lohnsteuer/2021-09-27-steuerliche-behandlung-reisekosten-reisekostenverguetungen-2022.html).

Thus no need for rate changes, except telling the tool that we have the rates for 2022 now.